### PR TITLE
Fix 0.6 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
+  - 0.6
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.5
 NullableArrays
 Compat 0.8.6

--- a/src/Cell.jl
+++ b/src/Cell.jl
@@ -7,9 +7,9 @@ A `Cell` is a single piece of data annotated by a column name
 """
 immutable Cell{Name, ElType}
     data::ElType
-    function Cell{T}(x::T)
+    function (::Type{Cell{Name, ElType}}){Name, ElType, T}(x::T)
         check_Cell(Val{Name},ElType)
-        new(convert(ElType,x))
+        new{Name, ElType}(convert(ElType,x))
     end
 end
 @compat @inline (::Type{Cell{Name}}){Name, ElType}(x::ElType) = Cell{Name,ElType}(x)

--- a/src/Column.jl
+++ b/src/Column.jl
@@ -4,9 +4,9 @@ A Column is a vector (or similar store) of data annotated by a column name
 """
 immutable Column{Name, StorageType}
     data::StorageType
-    function Column{T}(x::T)
+    function (::Type{Column{Name, StorageType}}){Name, StorageType, T}(x::T)
         check_Column(Val{Name}, StorageType)
-        new(convert(StorageType, x))
+        new{Name, StorageType}(convert(StorageType, x))
     end
 end
 

--- a/src/Row.jl
+++ b/src/Row.jl
@@ -8,9 +8,9 @@ A `Row` stores multiple elements of data referenced by their column names.
 immutable Row{Names, Types <: Tuple}
     data::Types
 
-    function Row{T <: Tuple}(data_in::T)
+    function (::Type{Row{Names, Types}}){Names, Types, T <: Tuple}(data_in::T)
         check_row(Val{Names}, Types)
-        new(convert(Types, data_in))
+        new{Names, Types}(convert(Types, data_in))
     end
 end
 

--- a/src/Table.jl
+++ b/src/Table.jl
@@ -21,7 +21,7 @@ A table stores columns of data accessible by their field names.
 immutable Table{Names, StorageTypes <: Tuple} #<: AbstractTable{Index,DefaultKey()}
     data::StorageTypes
 
-    function Table(data_in::Tuple, check_sizes::Type{Val{true}} = Val{true})
+    function (::Type{Table{Names, StorageTypes}}){Names, StorageTypes <: Tuple}(data_in::Tuple, check_sizes::Type{Val{true}} = Val{true})
         check_table(Val{Names}, StorageTypes)
         ls = map(length, data_in)
         for i in 2:length(data_in)
@@ -29,12 +29,12 @@ immutable Table{Names, StorageTypes <: Tuple} #<: AbstractTable{Index,DefaultKey
                 error("Column inputs must be same length.")
             end
         end
-        new(data_in)
+        new{Names, StorageTypes}(data_in)
     end
 
-    function Table(data_in::Tuple, check_sizes::Type{Val{false}})
+    function (::Type{Table{Names, StorageTypes}}){Names, StorageTypes}(data_in::Tuple, check_sizes::Type{Val{false}})
         check_table(Val{Names}, StorageTypes)
-        new(data_in)
+        new{Names, StorageTypes}(data_in)
     end
 end
 


### PR DESCRIPTION
There are 3 test failures in 0.6; those are not fixed by this PR. Two of the failures are world-age errors - I don't understand what's wrong there. The other is over `@Row(A::Int64 = 1, B::Float64 = 2.0) == @Row(B::Float64 = 2.0, A::Int64 = 1)`. Maybe I'll fix it in another PR.