### PR TITLE
Add a `getproperties` conenience function

### DIFF
--- a/docs/src/man/tutorial.md
+++ b/docs/src/man/tutorial.md
@@ -344,6 +344,8 @@ In fact, `Table` will know that getting a certain field of every row via `map` i
 as simply extracting the column `name`, and this operation will be fast. This will be most
 useful in the operations below.
 
+There is a similar function `getproperties` for selecting more than one column.
+
 ## Grouping data
 
 Frequently, one wishes to group and process data using a so-called "split-apply-combine"

--- a/src/FlexTable.jl
+++ b/src/FlexTable.jl
@@ -61,6 +61,8 @@ function Base.setproperty!(t::FlexTable, name::Symbol, ::Nothing)
     return t
 end
 
+propertytype(::FlexTable{N}) where {N} = FlexTable{N}
+
 """
     columnnames(table)
 

--- a/src/Table.jl
+++ b/src/Table.jl
@@ -87,6 +87,8 @@ function Base.setproperty!(t::Table, name::Symbol, a)
     error("type Table is immutable. Set the values of an existing column with the `.=` operator, e.g. `table.name .= array`.")
 end
 
+propertytype(::Table) = Table
+
 """
     columnnames(table)
 

--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -7,18 +7,7 @@ using SplitApplyCombine
 using Base: @propagate_inbounds, @pure, OneTo, Fix2
 import Tables.columns, Tables.rows
 
-export Table, FlexTable, columns, rows, columnnames, showtable
-
-# GetProperty
-struct GetProperty{name}
-end
-@inline GetProperty(name::Symbol) = GetProperty{name}()
-
-@inline function Base.getproperty(sym::Symbol)
-	return GetProperty(sym)
-end
-
-@inline (::GetProperty{name})(x) where {name} = getproperty(x, name)
+export Table, FlexTable, columns, rows, columnnames, showtable, getproperties
 
 # Resultant element type of given column arrays
 @generated function _eltypes(a::NamedTuple{names, T}) where {names, T <: Tuple{Vararg{AbstractArray}}}
@@ -44,6 +33,7 @@ let
     end
 end
 
+include("properties.jl")
 include("Table.jl")
 include("FlexTable.jl")
 include("columnops.jl")

--- a/src/columnops.jl
+++ b/src/columnops.jl
@@ -17,6 +17,10 @@ function Base.map(::GetProperty{name}, t::Union{Table{<:Any, N}, FlexTable{N}}) 
     return copy(getproperty(t, name::Symbol))::AbstractArray{<:Any, N}
 end
 
+@inline function Base.map(f::GetProperties{names}, t::Union{Table{<:Any, N}, FlexTable{N}}) where {names,  N}
+    return copy(f(t))
+end
+
 # In `mapview`, the output should alias the inputs
 function SplitApplyCombine.mapview(::typeof(merge), t1::Table, t2::Table)
     return Table(merge(columns(t1), columns(t2)))
@@ -30,6 +34,10 @@ end
     return getproperty(t, name::Symbol)::AbstractArray{<:Any, N}
 end
 
+@inline function SplitApplyCombine.mapview(f::GetProperties{names}, t::Union{Table{<:Any, N}, FlexTable{N}}) where {names,  N}
+    return f(t)
+end
+
 # broadcast
 
 @inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, ::typeof(merge), ts::Table{<:Any, N}...) where {N}
@@ -40,10 +48,18 @@ end
 	FlexTable{N}(merge(map(columns, ts)...))
 end
 
-@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty{names}, t::Table{<:Any, N}) where {N, name}
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty{name}, t::Table{<:Any, N}) where {N, name}
 	return getproperty(t, name::Symbol)
 end
 
-@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty{names}, t::FlexTable{N}) where {N, name}
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty{name}, t::FlexTable{N}) where {N, name}
 	return getproperty(t, name::Symbol)::AbstractArray{<:Any, N}
+end
+
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperties{names}, t::Table{<:Any, N}) where {N, names}
+    return f(t)
+end
+
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperties{names}, t::FlexTable{N}) where {N, names}
+    return f(t)
 end

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -1,0 +1,77 @@
+# GetProperty
+struct GetProperty{name} <: Function
+end
+@inline GetProperty(name::Symbol) = GetProperty{name}()
+
+"""
+    getproperty(name::Symbol)
+
+Return a curried function equivalent to `x -> getproperty(x, name)`.
+
+Internally, `name` is stored as a type parameter of a `GetProperty` object for the purpose
+of constant propagation. See also `getproperties`.
+
+# Example
+
+Extract property `b` from a `NamedTuple`.
+
+```julia
+julia> nt = (a = 1, b = 2.0, c = false)
+(a = 1, b = 2.0, c = false)
+
+julia> getproperty(:b)(nt)
+2.0
+```
+"""
+@inline function Base.getproperty(name::Symbol)
+    return GetProperty(name)
+end
+
+@inline (::GetProperty{name})(x) where {name} = getproperty(x, name)
+
+# GetProperties
+struct GetProperties{names} <: Function
+end
+
+@inline GetProperties(names::Tuple{Vararg{Symbol}}) = GetProperties{names}()
+
+"""
+    getproperties(names::Symbol...)
+
+Return a function that extracts a set of properties with the given `names` from an object,
+returning a new object with just those properties.
+
+Internally, the `names` are stored as a type parameter of a `GetProperties` object for the
+purpose of constant propagation. You may overload the `propertytype` function to control
+the type of the object that is returned, which by default will be a `NamedTuple`. See also
+`getproperty`.
+
+# Example
+
+Extract properties `a` and `c` from a `NamedTuple`.
+
+```julia
+julia> nt = (a = 1, b = 2.0, c = false)
+(a = 1, b = 2.0, c = false)
+
+julia> getproperties(:a, :c)(nt)
+(a = 1, c = false)
+```
+"""
+@inline function getproperties(names::Symbol...)
+    return GetProperties(names)
+end
+
+@generated function (::GetProperties{names})(x) where {names}
+    exprs = [:($n = getproperty(x, $(QuoteNode(n)))) for n in names]
+    return Expr(:call, Expr(:call, :propertytype, :x), Expr(:tuple, exprs...))
+end
+
+"""
+    propertytype(x)
+
+Return a constructor for an object similar to `x` that can accept a `NamedTuple` with
+arbitrary properties and support `getproperty`. Used for determining the return type of a
+`getproperties` function. The defaults return type is `NamedTuple`.
+"""
+propertytype(x) = identity # the input is always a `NamedTuple`

--- a/test/FlexTable.jl
+++ b/test/FlexTable.jl
@@ -33,7 +33,6 @@
     @test [t t; t t]::FlexTable{2} == FlexTable(a = [1 1;2 2;3 3;1 1;2 2;3 3], b = [2.0 2.0; 4.0 4.0; 6.0 6.0; 2.0 2.0; 4.0 4.0; 6.0 6.0])
     @test @inferred(vec(t))::FlexTable{1} == t
 
-
     io = IOBuffer()
     show(io, t)
     str = String(take!(io))
@@ -45,6 +44,7 @@
          2 │ 2  4.0
          3 │ 3  6.0"""
 
+    @test @inferred(getproperties(:b, :a)(t))::FlexTable == FlexTable(b = [2.0, 4.0, 6.0], a = [1, 2, 3])
 
     t2 = empty(t)
     @test t2 isa typeof(t)
@@ -120,6 +120,10 @@
         @test map(getproperty(:a), t)::Vector == [1,2,3]
         @test mapview(getproperty(:a), t)::Vector == [1,2,3]
         @test broadcast(getproperty(:a), t)::Vector == [1,2,3]
+
+        @test @inferred(map(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
+        @test @inferred(mapview(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
+        @test @inferred(broadcast(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
     end
 
     # setproperty!

--- a/test/Table.jl
+++ b/test/Table.jl
@@ -1,5 +1,5 @@
 @testset "Table" begin
-    t = @inferred(Table(a = [1,2,3], b = [2.0, 4.0, 6.0]))::Table
+    t = @inferred(Table(a = [1, 2, 3], b = [2.0, 4.0, 6.0]))::Table
 
     @test Table(t) == t
     @test Table(t; c = [true,false,true]) == Table(a = [1,2,3], b = [2.0,4.0,6.0], c = [true,false,true])
@@ -44,6 +44,8 @@
          1 │ 1  2.0
          2 │ 2  4.0
          3 │ 3  6.0"""
+
+    @test @inferred(getproperties(:b, :a)(t))::Table == Table(b = [2.0, 4.0, 6.0], a = [1, 2, 3])
 
     t2 = empty(t)
     @test t2 isa typeof(t)
@@ -119,6 +121,10 @@
         @test @inferred(map(getproperty(:a), t))::Vector == [1,2,3]
         @test @inferred(mapview(getproperty(:a), t))::Vector == [1,2,3]
         @test @inferred(broadcast(getproperty(:a), t))::Vector == [1,2,3]
+
+        @test @inferred(map(getproperties(:a), t))::Table == Table(a = [1,2,3])
+        @test @inferred(mapview(getproperties(:a), t))::Table == Table(a = [1,2,3])
+        @test @inferred(broadcast(getproperties(:a), t))::Table == Table(a = [1,2,3])
     end
 
     @testset "missing in tables" begin

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -1,0 +1,5 @@
+@testset "Property interface" begin
+    @test @inferred(getproperty(:b)((a=1,b=2.0,c=false))) === 2.0
+
+    @test @inferred(getproperties(:b)((a=1,b=2.0,c=false))) === (b = 2.0,)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,6 @@ using TypedTables
 using SplitApplyCombine
 using Tables
 
+include("properties.jl")
 include("Table.jl")
 include("FlexTable.jl")


### PR DESCRIPTION
One can pick more than one column with `getproperties`. The output type is configurable by a `propertytype` function - defaulting to NamedTuple.

```julia
julia> nt = (a = 1, b = 2.0, c = false)
(a = 1, b = 2.0, c = false)
 julia> getproperties(:a, :c)(nt)
(a = 1, c = false)
```
Similarly, a table returns a table

```julia
julia> t = Table(a = [1,2,3], b = [2.0, 4.0, 6.0])
Table with 2 columns and 3 rows:
     a  b
   ┌───────
 1 │ 1  2.0
 2 │ 2  4.0
 3 │ 3  6.0

julia> getproperties(:b, :a)(t)
Table with 2 columns and 3 rows:
     b    a
   ┌───────
 1 │ 2.0  1
 2 │ 4.0  2
 3 │ 6.0  3
```

This begins to form the basis of a "properties" interface. We will need a few more convenience functions yet, like a generic "select" that is friendly for columnar storage.