### PR TITLE
RFC: Property interface via macros `@Select` and `@Compute`

### DIFF
--- a/docs/src/man/group.md
+++ b/docs/src/man/group.md
@@ -4,7 +4,6 @@ It is frequently useful to break data appart into different *groups* for process
 
 In a powerful environment such as Julia, that fully supports nested containers, it makes sense to represent each group as distinct containers, with an outer container acting as a "dictionary" of the groups. This is in contrast to environments with a less rich system of containers, such as SQL, which has popularized a slightly different notion of grouping data into a single flat tabular structure, where one (or more) columns act as the grouping key. Here we focus on the former approach.
 
-
 ## Using the `group` function
 
 *SplitApplyCombine* provides a `group` function, which can operate on arbitary Julia objects. The function has the signature `group(by, f, iter)` where `iter` is a container that can be iterated, `by` is a function from the elements of `iter` to the grouping *key*, and the optional argument `f` is a mapping applied to the grouped elements (by default, `f = identity`, the identity function).

--- a/docs/src/man/reference.md
+++ b/docs/src/man/reference.md
@@ -19,3 +19,12 @@ TypedTables.FlexTable
 TypedTables.columns
 TypedTables.columnnames
 ```
+
+## Convenience macros
+
+These macros return *functions* that can be applied to tables and rows.
+
+```@docs
+TypedTables.@Compute
+TypedTables.@Select
+```

--- a/docs/src/man/tutorial.md
+++ b/docs/src/man/tutorial.md
@@ -327,24 +327,55 @@ Table with 2 columns and 3 rows:
  3 │ C        false
 ```
 
-It is worth being aware of a special function `getproperty`, which is Julia's function for
-the `.` operator - that is `a.b` is just convenient shorthand syntax for
-`getproperty(a, :b)`. The function `getproperty(:b)` returns *another function* such that
-`getproperty(:b)(a)` is the same as `a.b`. If you wish to programmatically select a column
-of a Table, you can use `getproperty` to do so.
+Writing anonymous functions can become laborious when dealing with many rows, so the
+convenience macros `@Select` and `@Compute` are provided to aid in their construction.
+
+The `@Select` macro returns a function that can map a row to a new row (or a table to a
+new table) by defining a functional mapping for each output column. The above example can
+alternatively be written as:
 
 ```julia
-julia> map(getproperty(:name), t)
+julia> map(@Select(initial = first($name), is_old = $age > 40), t)
+Table with 2 columns and 3 rows:
+     initial  is_old
+   ┌────────────────
+ 1 │ A        false
+ 2 │ B        true
+ 3 │ C        false
+```
+
+For shorthand, the `= ...` can be ommited to simply extract a column. For example, we can
+reorder the columns via
+
+```
+julia> @Select(age, name)(t)
+Table with 2 columns and 3 rows:
+     age  name
+   ┌─────────────
+ 1 │ 25   Alice
+ 2 │ 42   Bob
+ 3 │ 37   Charlie
+```
+(Note that here we "select" columns directly, rather than using `map` to select the fields
+of each row.)
+
+The `@Compute` macro returns a function that maps a row to a value. As for `@Select`, the
+input column names are prepended with `$`, for example:
+
+```julia
+julia> map(@Compute($name), t)
 3-element Array{String,1}:
  "Alice"  
  "Bob"    
  "Charlie"
 ```
-In fact, `Table` will know that getting a certain field of every row via `map` is the same
-as simply extracting the column `name`, and this operation will be fast. This will be most
-useful in the operations below.
 
-There is a similar function `getproperties` for selecting more than one column.
+Unlike an anonymous function, these two macros create an introspectable function that allows
+computations to take advantage of columnar storage and advanced features like acceleration
+indices. You may find calculations may be performed faster with the macros for a wide
+variety of functions like `map`, `broadcast`, `filter`, `findall`, `reduce`, `group` and
+`innerjoin`. For instance, the example above simply extracts the `name` column from `t`,
+without performing an explicit map.
 
 ## Grouping data
 
@@ -394,7 +425,7 @@ Sometimes you may want to transform the grouped data - you can do so by passing 
 mapping function. For example, we may want to group firstnames by lastname.
 
 ```julia
-julia> group(getproperty(:lastname), getproperty(:firstname), t2)
+julia> group(@Compute($lastname), $Compute($firstname), t2)
 Dict{String,Array{String,1}} with 4 entries:
   "King"     => ["Arthur"]
   "Williams" => ["Adam", "Eve"]
@@ -408,7 +439,7 @@ If instead, our group elements are rows (named tuples), each group will itslef b
 For example, we can keep the entire row by dropping the second function.
 
 ```julia
-julia> families = group(getproperty(:lastname), t2)
+julia> families = group(@Compute($lastname), t2)
 Groups{String,Any,Table{NamedTuple{(:firstname, :lastname, :age),Tuple{String,String,Int64}},1,NamedTuple{(:firstname, :lastname, :age),Tuple{Array{String,1},Array{String,1},Array{Int64,1}}}},Dict{String,Array{Int64,1}}} with 4 entries:
   "King"     => Table with 3 columns and 1 row:…
   "Williams" => Table with 3 columns and 2 rows:…
@@ -419,7 +450,7 @@ Groups{String,Any,Table{NamedTuple{(:firstname, :lastname, :age),Tuple{String,St
 The results are only summarized above (for compactness), but can be easily accessed.
 
 ```julia
-julia> familes["Smith"]
+julia> families["Smith"]
 Table with 3 columns and 3 rows:
      firstname  lastname  age
    ┌─────────────────────────
@@ -467,7 +498,7 @@ function expects two functions, to describe the joining key of the first table a
 joining key of the second table. We will use `getproperty` to select the columns.
 
 ```julia
-julia> innerjoin(getproperty(:id), getproperty(:customer_id), customers, orders)
+julia> innerjoin(@Compute($id), @Compute($customer_id), customers, orders)
 Table with 5 columns and 4 rows:
      id  name     address          customer_id  items
    ┌─────────────────────────────────────────────────────

--- a/docs/src/man/tutorial.md
+++ b/docs/src/man/tutorial.md
@@ -344,6 +344,8 @@ In fact, `Table` will know that getting a certain field of every row via `map` i
 as simply extracting the column `name`, and this operation will be fast. This will be most
 useful in the operations below.
 
+There is a similar function `getproperties` for selecting more than one column.
+
 ## Grouping data
 
 Frequently, one wishes to group and process data using a so-called "split-apply-combine"

--- a/src/FlexTable.jl
+++ b/src/FlexTable.jl
@@ -266,4 +266,31 @@ function Base.vec(t::FlexTable)
     return FlexTable{1}(map(vec, columns(t)))
 end
 
+# "Bulk" operations on FlexTables should generally first unrwap to Tables
+_flex(t::Table{<:Any, N}) where {N} = FlexTable(columns(t))
+_flex(t) = t
+
+Broadcast.broadcastable(t::FlexTable) = Table(t)
+
+Base.map(f, t::FlexTable{N}) where {N} = _flex(map(f, rows(t)))::AbstractArray{<:Any, N}
+Base.map(f, t::FlexTable{N}, t2) where {N} = _flex(map(f, rows(t), t2))::AbstractArray{<:Any, N}
+Base.map(f, t, t2::FlexTable{N}) where {N} = _flex(map(f, t, rows(t2)))::AbstractArray{<:Any, N}
+Base.map(f, t::FlexTable{N}, t2::FlexTable{N}) where {N} = _flex(map(f, rows(t), rows(t2)))::AbstractArray{<:Any, N}
+
+Base.mapreduce(f, op, t::FlexTable; kwargs...) = mapreduce(f, op, rows(t); kwargs...)
+
+Base.filter(f, t::FlexTable{N}) where {N} = FlexTable(filter(f, rows(t)))::FlexTable{N}
+
+SplitApplyCombine.mapview(f, t::FlexTable{N}) where {N} = _flex(mapview(f, rows(t)))::AbstractArray{<:Any, N}
+SplitApplyCombine.mapview(f, t::FlexTable{N}, t2) where {N} = _flex(mapview(f, rows(t), t2))::AbstractArray{<:Any, N}
+SplitApplyCombine.mapview(f, t, t2::FlexTable{N}) where {N} = _flex(mapview(f, t, rows(t2)))::AbstractArray{<:Any, N}
+SplitApplyCombine.mapview(f, t::FlexTable{N}, t2::FlexTable{N}) where {N} = _flex(mapview(f, rows(t), rows(t2)))::AbstractArray{<:Any, N}
+
 SplitApplyCombine.group(by, f, t::FlexTable) = group(by, f, rows(t))
+SplitApplyCombine.groupview(by, f, t::FlexTable) = groupview(by, f, rows(t))
+SplitApplyCombine.groupinds(by, t::FlexTable) = groupinds(by, rows(t))
+SplitApplyCombine.groupreduce(by, f, op, t::FlexTable; kwargs...) = groupreduce(by, f, op, rows(t); kwargs...)
+
+SplitApplyCombine.innerjoin(lkey, rkey, f, cmp, t1::FlexTable, t2) = _flex(innerjoin(lkey, rkey, f, cmp, rows(t1), t2))
+SplitApplyCombine.innerjoin(lkey, rkey, f, cmp, t1, t2::FlexTable) = _flex(innerjoin(lkey, rkey, f, cmp, t1, rows(t2)))
+SplitApplyCombine.innerjoin(lkey, rkey, f, cmp, t1::FlexTable, t2::FlexTable) = _flex(innerjoin(lkey, rkey, f, cmp, rows(t1), rows(t2)))

--- a/src/FlexTable.jl
+++ b/src/FlexTable.jl
@@ -294,3 +294,17 @@ SplitApplyCombine.groupreduce(by, f, op, t::FlexTable; kwargs...) = groupreduce(
 SplitApplyCombine.innerjoin(lkey, rkey, f, cmp, t1::FlexTable, t2) = _flex(innerjoin(lkey, rkey, f, cmp, rows(t1), t2))
 SplitApplyCombine.innerjoin(lkey, rkey, f, cmp, t1, t2::FlexTable) = _flex(innerjoin(lkey, rkey, f, cmp, t1, rows(t2)))
 SplitApplyCombine.innerjoin(lkey, rkey, f, cmp, t1::FlexTable, t2::FlexTable) = _flex(innerjoin(lkey, rkey, f, cmp, rows(t1), rows(t2)))
+
+Base.:(==)(t1::FlexTable{N}, t2::AbstractArray{<:Any,N}) where {N} = (rows(t1) == t2)
+Base.:(==)(t1::AbstractArray{<:Any,N}, t2::FlexTable{N}) where {N} = (t1 == rows(t2))
+Base.:(==)(t1::FlexTable{N}, t2::FlexTable{N}) where {N} = (rows(t1) == rows(t2))
+
+Base.isequal(t1::FlexTable{N}, t2::AbstractArray{<:Any,N}) where {N} = isequal(rows(t1), t2)
+Base.isequal(t1::AbstractArray{<:Any,N}, t2::FlexTable{N}) where {N} = isequal(t1, rows(t2))
+Base.isequal(t1::FlexTable{N}, t2::FlexTable{N}) where {N} = isequal(rows(t1), rows(t2))
+
+Base.isless(t1::FlexTable{1}, t2::AbstractVector) = isless(rows(t1), t2)
+Base.isless(t1::AbstractVector, t2::FlexTable{1}) = isless(t1, rows(t2))
+Base.isless(t1::FlexTable{1}, t2::FlexTable{1}) = isless(rows(t1), rows(t2))
+
+Base.hash(t::FlexTable, h::UInt) = hash(rows(t), h)

--- a/src/FlexTable.jl
+++ b/src/FlexTable.jl
@@ -61,6 +61,8 @@ function Base.setproperty!(t::FlexTable, name::Symbol, ::Nothing)
     return t
 end
 
+propertytype(::FlexTable{N}) where {N} = FlexTable{N}
+
 """
     columnnames(table)
 

--- a/src/Table.jl
+++ b/src/Table.jl
@@ -87,6 +87,8 @@ function Base.setproperty!(t::Table, name::Symbol, a)
     error("type Table is immutable. Set the values of an existing column with the `.=` operator, e.g. `table.name .= array`.")
 end
 
+propertytype(::Table) = Table
+
 """
     columnnames(table)
 

--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -7,8 +7,8 @@ using SplitApplyCombine
 using Base: @propagate_inbounds, @pure, OneTo, Fix2
 import Tables.columns, Tables.rows
 
-export @compute, @select
-export Table, FlexTable, columns, rows, columnnames, showtable, getproperties
+export @Compute, @Select
+export Table, FlexTable, columns, rows, columnnames, showtable
 
 # Resultant element type of given column arrays
 @generated function _eltypes(a::NamedTuple{names, T}) where {names, T <: Tuple{Vararg{AbstractArray}}}

--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -7,7 +7,7 @@ using SplitApplyCombine
 using Base: @propagate_inbounds, @pure, OneTo, Fix2
 import Tables.columns, Tables.rows
 
-export @calc, @select
+export @compute, @select
 export Table, FlexTable, columns, rows, columnnames, showtable, getproperties
 
 # Resultant element type of given column arrays

--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -7,18 +7,7 @@ using SplitApplyCombine
 using Base: @propagate_inbounds, @pure, OneTo, Fix2
 import Tables.columns, Tables.rows
 
-export Table, FlexTable, columns, rows, columnnames, showtable
-
-# GetProperty
-struct GetProperty{name}
-end
-@inline GetProperty(name::Symbol) = GetProperty{name}()
-
-@inline function Base.getproperty(sym::Symbol)
-	return GetProperty(sym)
-end
-
-@inline (::GetProperty{name})(x) where {name} = getproperty(x, name)
+export Table, FlexTable, columns, rows, columnnames, showtable, getproperties
 
 # Resultant element type of given column arrays
 @generated function _eltypes(a::NamedTuple{names, T}) where {names, T <: Tuple{Vararg{AbstractArray}}}
@@ -44,6 +33,7 @@ let
     end
 end
 
+include("properties.jl")
 include("Table.jl")
 include("FlexTable.jl")
 include("columnops.jl")

--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -7,6 +7,7 @@ using SplitApplyCombine
 using Base: @propagate_inbounds, @pure, OneTo, Fix2
 import Tables.columns, Tables.rows
 
+export @calc, @select
 export Table, FlexTable, columns, rows, columnnames, showtable, getproperties
 
 # Resultant element type of given column arrays

--- a/src/columnops.jl
+++ b/src/columnops.jl
@@ -1,41 +1,63 @@
 # Column-based operations: Some operations on rows are faster when considering columns
 
 # In `map`, the output shouldn't alias inputs, so copies are made
-Base.map(::typeof(identity), t::Union{FlexTable, Table}) = copy(t)
+Base.map(::typeof(identity), t::Table) = copy(t)
 
-Base.map(::typeof(merge), t::Union{FlexTable, Table}) = copy(t)
+Base.map(::typeof(merge), t::Table) = copy(t)
 
 function Base.map(::typeof(merge), t1::Table, t2::Table)
     return copy(Table(merge(columns(t1), columns(t2))))
 end
 
-function Base.map(::typeof(merge), df1::Union{Table{<:Any, N}, FlexTable{N}}, df2::Union{Table{<:Any, N}, FlexTable{N}}) where {N}
-    return copy(FlexTable{N}(merge(columns(df1), columns(df2))))
-end
-
-function Base.map(::GetProperty{name}, t::Union{Table{<:Any, N}, FlexTable{N}}) where {name, N}
-    return copy(getproperty(t, name::Symbol))::AbstractArray{<:Any, N}
-end
-
-@inline function Base.map(f::GetProperties{names}, t::Union{Table{<:Any, N}, FlexTable{N}}) where {names,  N}
+function Base.map(f::GetProperty, t::Table)
     return copy(f(t))
 end
 
+@inline function Base.map(f::GetProperties, t::Table)
+    return copy(f(t))
+end
+
+@inline function Base.map(f::Calc{names}, t::Table) where {names}
+    map(f, GetProperties(names)(t))
+end
+
+@inline function Base.map(f::Calc{names}, t::Table{<:NamedTuple{names}}) where {names}
+    invoke(map, Tuple{Function, typeof(t)}, f, t)
+end
+
+@generated function Base.map(s::Select{names}, t::Table) where {names}
+    exprs = [:($(names[i]) = map(s.calcs[$i], t)) for i in 1:length(names)]
+
+    return :(Table($(Expr(:tuple, exprs...))))
+end
+
 # In `mapview`, the output should alias the inputs
+SplitApplyCombine.mapview(::typeof(merge), t::Table) = t
+
 function SplitApplyCombine.mapview(::typeof(merge), t1::Table, t2::Table)
     return Table(merge(columns(t1), columns(t2)))
 end
 
-function SplitApplyCombine.mapview(::typeof(merge), df1::Union{Table{<:Any, N}, FlexTable{N}}, df2::Union{Table{<:Any, N}, FlexTable{N}}) where {N}
-    return FlexTable{N}(merge(columns(df1), columns(df2)))
-end
-
-@inline function SplitApplyCombine.mapview(f::GetProperty{name}, t::Union{Table{<:Any, N}, FlexTable{N}}) where {name,  N}
-    return getproperty(t, name::Symbol)::AbstractArray{<:Any, N}
-end
-
-@inline function SplitApplyCombine.mapview(f::GetProperties{names}, t::Union{Table{<:Any, N}, FlexTable{N}}) where {names,  N}
+@inline function SplitApplyCombine.mapview(f::GetProperty, t::Table)
     return f(t)
+end
+
+@inline function SplitApplyCombine.mapview(f::GetProperties, t::Table)
+    return f(t)
+end
+
+@inline function SplitApplyCombine.mapview(f::Calc{names}, t::Table) where {names}
+    mapview(f, GetProperties(names)(t))
+end
+
+@inline function SplitApplyCombine.mapview(f::Calc{names}, t::Table{<:NamedTuple{names}}) where {names}
+    invoke(mapview, Tuple{Function, typeof(t)}, f, t)
+end
+
+@generated function SplitApplyCombine.mapview(s::Select{names}, t::Table) where {names}
+    exprs = [:($(names[i]) = mapview(s.calcs[$i], t)) for i in 1:length(names)]
+
+    return :(Table($(Expr(:tuple, exprs...))))
 end
 
 # broadcast
@@ -44,22 +66,27 @@ end
 	Table(merge(map(columns, ts)...))
 end
 
-@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, ::typeof(merge), ts::Union{Table{<:Any, N},FlexTable{N}}...) where {N}
-	FlexTable{N}(merge(map(columns, ts)...))
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty, t::Table{<:Any, N}) where {N}
+	return f(t)
 end
 
-@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty{name}, t::Table{<:Any, N}) where {N, name}
-	return getproperty(t, name::Symbol)
-end
-
-@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty{name}, t::FlexTable{N}) where {N, name}
-	return getproperty(t, name::Symbol)::AbstractArray{<:Any, N}
-end
-
-@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperties{names}, t::Table{<:Any, N}) where {N, names}
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperties, t::Table{<:Any, N}) where {N}
     return f(t)
 end
 
-@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperties{names}, t::FlexTable{N}) where {N, names}
-    return f(t)
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::Calc, t::Table{<:Any, N}) where {N}
+    return Broadcast.Broadcasted{Broadcast.DefaultArrayStyle{N}}(f, (t,), axes(t))
 end
+
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::Select, t::Table{<:Any, N}) where {N}
+    return mapview(f, t)
+end
+
+# I'm not 100% sure how wise this pattern is...
+Broadcast.materialize(t::Table) = Table(map(_materialize, columns(t)))
+_materialize(x) = Broadcast.materialize(x)
+_materialize(x::MappedArray) = copy(x)
+
+# TODO filter
+
+# TODO mapreduce

--- a/src/columnops.jl
+++ b/src/columnops.jl
@@ -24,6 +24,12 @@ end
 
 @inline function Base.map(f::Compute{names}, t::Table{<:NamedTuple{names}}) where {names}
     # efficient to iterate over rows with a minimal number of columns
+    if length(names) == 1 # unwrap in the simple cases
+        return map(f.f, getproperty(names[1])(t))
+    elseif length(names) == 2
+        return map(f.f, getproperty(names[1])(t), getproperty(names[2])(t))
+    end
+
     invoke(map, Tuple{Function, typeof(t)}, f, t)
 end
 
@@ -55,6 +61,10 @@ end
 
 @inline function SplitApplyCombine.mapview(f::Compute{names}, t::Table{<:NamedTuple{names}}) where {names}
     # efficient to iterate over rows with a minimal number of columns
+    if length(names) == 1 # unwrap in the simple cases (consider 2-argument version)
+        return mapview(f.f, getproperty(names[1])(t))
+    end
+
     invoke(mapview, Tuple{Function, typeof(t)}, f, t)
 end
 
@@ -85,6 +95,12 @@ end
 
 @inline function Broadcast.broadcasted(style::Broadcast.DefaultArrayStyle{N}, f::Compute{names}, t::Table{<:NamedTuple{names}, N}) where {N, names}
     # efficient to iterate over rows with a minimal number of columns
+    if length(names) == 1 # unwrap in the simple cases
+        return Broadcast.broadcasted(f.f, getproperty(names[1])(t))
+    elseif length(names) == 2
+        return Broadcast.broadcasted(f.f, getproperty(names[1])(t), getproperty(names[2])(t))
+    end
+
     invoke(Broadcast.broadcasted, Tuple{typeof(style), Function, typeof(t)}, style, f, t)
 end
 
@@ -115,6 +131,12 @@ end
 
 function Base.mapreduce(f::Compute{names}, op, t::Table{<:NamedTuple{names}}; kwargs...) where {names}
     # efficient to iterate over rows with a minimal number of columns
+    if length(names) == 1 # unwrap in the simple cases
+        return mapreduce(f.f, op, getproperty(names[1])(t))
+    elseif length(names) == 2
+        return mapreduce(f.f, op, getproperty(names[1])(t), getproperty(names[2])(t))
+    end
+    
     invoke(mapreduce, Tuple{Function, typeof(op), typeof(t)}, f, op, t; kwargs...)
 end
 
@@ -137,5 +159,9 @@ end
 
 function Base.findall(f::Compute{names}, t::Table{<:NamedTuple{names}}) where {names}
     # efficient to iterate over rows with a minimal number of columns
+    if length(names) == 1 # unwrap in the simple cases
+        return findall(f.f, getproperty(names[1])(t))
+    end
+
     invoke(findall, Tuple{Function, typeof(t)}, f, t)
 end

--- a/src/columnops.jl
+++ b/src/columnops.jl
@@ -17,18 +17,18 @@ end
     return copy(f(t))
 end
 
-@inline function Base.map(f::Calc{names}, t::Table) where {names}
+@inline function Base.map(f::Compute{names}, t::Table) where {names}
     # minimize number of columns before iterating over the rows
     map(f, GetProperties(names)(t))
 end
 
-@inline function Base.map(f::Calc{names}, t::Table{<:NamedTuple{names}}) where {names}
+@inline function Base.map(f::Compute{names}, t::Table{<:NamedTuple{names}}) where {names}
     # efficient to iterate over rows with a minimal number of columns
     invoke(map, Tuple{Function, typeof(t)}, f, t)
 end
 
 @generated function Base.map(s::Select{names}, t::Table) where {names}
-    exprs = [:($(names[i]) = map(s.calcs[$i], t)) for i in 1:length(names)]
+    exprs = [:($(names[i]) = map(s.fs[$i], t)) for i in 1:length(names)]
 
     return :(Table($(Expr(:tuple, exprs...))))
 end
@@ -48,18 +48,18 @@ end
     return f(t)
 end
 
-@inline function SplitApplyCombine.mapview(f::Calc{names}, t::Table) where {names}
+@inline function SplitApplyCombine.mapview(f::Compute{names}, t::Table) where {names}
     # minimize number of columns before iterating over the rows
     mapview(f, GetProperties(names)(t))
 end
 
-@inline function SplitApplyCombine.mapview(f::Calc{names}, t::Table{<:NamedTuple{names}}) where {names}
+@inline function SplitApplyCombine.mapview(f::Compute{names}, t::Table{<:NamedTuple{names}}) where {names}
     # efficient to iterate over rows with a minimal number of columns
     invoke(mapview, Tuple{Function, typeof(t)}, f, t)
 end
 
 @generated function SplitApplyCombine.mapview(s::Select{names}, t::Table) where {names}
-    exprs = [:($(names[i]) = mapview(s.calcs[$i], t)) for i in 1:length(names)]
+    exprs = [:($(names[i]) = mapview(s.fs[$i], t)) for i in 1:length(names)]
 
     return :(Table($(Expr(:tuple, exprs...))))
 end
@@ -78,12 +78,12 @@ end
     return f(t)
 end
 
-@inline function Broadcast.broadcasted(style::Broadcast.DefaultArrayStyle{N}, f::Calc{names}, t::Table{<:NamedTuple, N}) where {N, names}
+@inline function Broadcast.broadcasted(style::Broadcast.DefaultArrayStyle{N}, f::Compute{names}, t::Table{<:NamedTuple, N}) where {N, names}
     # minimize number of columns before iterating over the rows
     return Broadcast.broadcasted(style, f, GetProperties(names)(t))
 end
 
-@inline function Broadcast.broadcasted(style::Broadcast.DefaultArrayStyle{N}, f::Calc{names}, t::Table{<:NamedTuple{names}, N}) where {N, names}
+@inline function Broadcast.broadcasted(style::Broadcast.DefaultArrayStyle{N}, f::Compute{names}, t::Table{<:NamedTuple{names}, N}) where {N, names}
     # efficient to iterate over rows with a minimal number of columns
     invoke(Broadcast.broadcasted, Tuple{typeof(style), Function, typeof(t)}, style, f, t)
 end
@@ -107,13 +107,13 @@ function Base.mapreduce(f::GetProperties, op, t::Table; kwargs...)
     return mapreduce(identity, op, f(t); kwargs...)
 end
 
-function Base.mapreduce(f::Calc{names}, op, t::Table; kwargs...) where {names}
+function Base.mapreduce(f::Compute{names}, op, t::Table; kwargs...) where {names}
     # minimize number of columns before iterating over the rows
     t2 = GetProperties(names)(t)
     return mapreduce(f, op, t2; kwargs...)
 end
 
-function Base.mapreduce(f::Calc{names}, op, t::Table{<:NamedTuple{names}}; kwargs...) where {names}
+function Base.mapreduce(f::Compute{names}, op, t::Table{<:NamedTuple{names}}; kwargs...) where {names}
     # efficient to iterate over rows with a minimal number of columns
     invoke(mapreduce, Tuple{Function, typeof(op), typeof(t)}, f, op, t; kwargs...)
 end
@@ -130,12 +130,12 @@ function Base.findall(f::GetProperty, t::Table)
     return findall(identity, f(t))
 end
 
-function Base.findall(f::Calc{names}, t::Table) where {names}
+function Base.findall(f::Compute{names}, t::Table) where {names}
     # minimize number of columns before iterating over the rows
     return findall(f, GetProperties(names)(t))
 end
 
-function Base.findall(f::Calc{names}, t::Table{<:NamedTuple{names}}) where {names}
+function Base.findall(f::Compute{names}, t::Table{<:NamedTuple{names}}) where {names}
     # efficient to iterate over rows with a minimal number of columns
     invoke(findall, Tuple{Function, typeof(t)}, f, t)
 end

--- a/src/columnops.jl
+++ b/src/columnops.jl
@@ -99,15 +99,23 @@ _materialize(x::MappedArray) = copy(x)
 
 # mapreduce
 
+function Base.mapreduce(f::GetProperty, op, t::Table; kwargs...)
+    return mapreduce(identity, op, f(t); kwargs...)
+end
+
+function Base.mapreduce(f::GetProperties, op, t::Table; kwargs...)
+    return mapreduce(identity, op, f(t); kwargs...)
+end
+
 function Base.mapreduce(f::Calc{names}, op, t::Table; kwargs...) where {names}
     # minimize number of columns before iterating over the rows
     t2 = GetProperties(names)(t)
-    return mapreduce(f, op, t; kwargs...)
+    return mapreduce(f, op, t2; kwargs...)
 end
 
-function Base.mapreduce(f::Calc{names}, op, t::Table{names}; kwargs...) where {names}
+function Base.mapreduce(f::Calc{names}, op, t::Table{<:NamedTuple{names}}; kwargs...) where {names}
     # efficient to iterate over rows with a minimal number of columns
-    invoke(mapreduce, Tuple{Function, typeof(of), typeof(t)}, f, op, t; kwargs...)
+    invoke(mapreduce, Tuple{Function, typeof(op), typeof(t)}, f, op, t; kwargs...)
 end
 
 # `filter(f, t)` defaults to `t[map(f, t)]`

--- a/src/columnops.jl
+++ b/src/columnops.jl
@@ -18,10 +18,12 @@ end
 end
 
 @inline function Base.map(f::Calc{names}, t::Table) where {names}
+    # minimize number of columns before iterating over the rows
     map(f, GetProperties(names)(t))
 end
 
 @inline function Base.map(f::Calc{names}, t::Table{<:NamedTuple{names}}) where {names}
+    # efficient to iterate over rows with a minimal number of columns
     invoke(map, Tuple{Function, typeof(t)}, f, t)
 end
 
@@ -47,10 +49,12 @@ end
 end
 
 @inline function SplitApplyCombine.mapview(f::Calc{names}, t::Table) where {names}
+    # minimize number of columns before iterating over the rows
     mapview(f, GetProperties(names)(t))
 end
 
 @inline function SplitApplyCombine.mapview(f::Calc{names}, t::Table{<:NamedTuple{names}}) where {names}
+    # efficient to iterate over rows with a minimal number of columns
     invoke(mapview, Tuple{Function, typeof(t)}, f, t)
 end
 
@@ -74,8 +78,14 @@ end
     return f(t)
 end
 
-@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::Calc, t::Table{<:Any, N}) where {N}
-    return Broadcast.Broadcasted{Broadcast.DefaultArrayStyle{N}}(f, (t,), axes(t))
+@inline function Broadcast.broadcasted(style::Broadcast.DefaultArrayStyle{N}, f::Calc{names}, t::Table{<:NamedTuple, N}) where {N, names}
+    # minimize number of columns before iterating over the rows
+    return Broadcast.broadcasted(style, f, GetProperties(names)(t))
+end
+
+@inline function Broadcast.broadcasted(style::Broadcast.DefaultArrayStyle{N}, f::Calc{names}, t::Table{<:NamedTuple{names}, N}) where {N, names}
+    # efficient to iterate over rows with a minimal number of columns
+    invoke(Broadcast.broadcasted, Tuple{typeof(style), Function, typeof(t)}, style, f, t)
 end
 
 @inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::Select, t::Table{<:Any, N}) where {N}
@@ -87,6 +97,37 @@ Broadcast.materialize(t::Table) = Table(map(_materialize, columns(t)))
 _materialize(x) = Broadcast.materialize(x)
 _materialize(x::MappedArray) = copy(x)
 
-# TODO filter
+# mapreduce
 
-# TODO mapreduce
+function Base.mapreduce(f::Calc{names}, op, t::Table; kwargs...) where {names}
+    # minimize number of columns before iterating over the rows
+    t2 = GetProperties(names)(t)
+    return mapreduce(f, op, t; kwargs...)
+end
+
+function Base.mapreduce(f::Calc{names}, op, t::Table{names}; kwargs...) where {names}
+    # efficient to iterate over rows with a minimal number of columns
+    invoke(mapreduce, Tuple{Function, typeof(of), typeof(t)}, f, op, t; kwargs...)
+end
+
+# `filter(f, t)` defaults to `t[map(f, t)]`
+
+function Base.filter(f::GetProperty, t::Table)
+    return @inbounds t[f(t)::AbstractArray{Bool}]
+end
+
+# findall
+
+function Base.findall(f::GetProperty, t::Table)
+    return findall(identity, f(t))
+end
+
+function Base.findall(f::Calc{names}, t::Table) where {names}
+    # minimize number of columns before iterating over the rows
+    return findall(f, GetProperties(names)(t))
+end
+
+function Base.findall(f::Calc{names}, t::Table{<:NamedTuple{names}}) where {names}
+    # efficient to iterate over rows with a minimal number of columns
+    invoke(findall, Tuple{Function, typeof(t)}, f, t)
+end

--- a/src/columnops.jl
+++ b/src/columnops.jl
@@ -17,6 +17,10 @@ function Base.map(::GetProperty{name}, t::Union{Table{<:Any, N}, FlexTable{N}}) 
     return copy(getproperty(t, name::Symbol))::AbstractArray{<:Any, N}
 end
 
+@inline function Base.map(f::GetProperties{names}, t::Union{Table{<:Any, N}, FlexTable{N}}) where {names,  N}
+    return copy(f(t))
+end
+
 # In `mapview`, the output should alias the inputs
 function SplitApplyCombine.mapview(::typeof(merge), t1::Table, t2::Table)
     return Table(merge(columns(t1), columns(t2)))
@@ -30,6 +34,10 @@ end
     return getproperty(t, name::Symbol)::AbstractArray{<:Any, N}
 end
 
+@inline function SplitApplyCombine.mapview(f::GetProperties{names}, t::Union{Table{<:Any, N}, FlexTable{N}}) where {names,  N}
+    return f(t)
+end
+
 # broadcast
 
 @inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, ::typeof(merge), ts::Table{<:Any, N}...) where {N}
@@ -40,10 +48,18 @@ end
 	FlexTable{N}(merge(map(columns, ts)...))
 end
 
-@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty{names}, t::Table{<:Any, N}) where {N, name}
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty{name}, t::Table{<:Any, N}) where {N, name}
 	return getproperty(t, name::Symbol)
 end
 
-@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty{names}, t::FlexTable{N}) where {N, name}
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperty{name}, t::FlexTable{N}) where {N, name}
 	return getproperty(t, name::Symbol)::AbstractArray{<:Any, N}
+end
+
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperties{names}, t::Table{<:Any, N}) where {N, names}
+    return f(t)
+end
+
+@inline function Broadcast.broadcasted(::Broadcast.DefaultArrayStyle{N}, f::GetProperties{names}, t::FlexTable{N}) where {N, names}
+    return f(t)
 end

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -1,0 +1,77 @@
+# GetProperty
+struct GetProperty{name} <: Function
+end
+@inline GetProperty(name::Symbol) = GetProperty{name}()
+
+"""
+    getproperty(name::Symbol)
+
+Return a curried function equivalent to `x -> getproperty(x, name)`.
+
+Internally, `name` is stored as a type parameter of a `GetProperty` object for the purpose
+of constant propagation. See also `getproperties`.
+
+# Example
+
+Extract property `b` from a `NamedTuple`.
+
+```julia
+julia> nt = (a = 1, b = 2.0, c = false)
+(a = 1, b = 2.0, c = false)
+
+julia> getproperty(:b)(nt)
+2.0
+```
+"""
+@inline function Base.getproperty(name::Symbol)
+    return GetProperty(name)
+end
+
+@inline (::GetProperty{name})(x) where {name} = getproperty(x, name)
+
+# GetProperties
+struct GetProperties{names} <: Function
+end
+
+@inline GetProperties(names::Tuple{Vararg{Symbol}}) = GetProperties{names}()
+
+"""
+    getproperties(names::Symbol...)
+
+Return a function that extracts a set of properties with the given `names` from an object,
+returning a new object with just those properties.
+
+Internally, the `names` are stored as a type parameter of a `GetProperties` object for the
+purpose of constant propagation. You may overload the `propertytype` function to control
+the type of the object that is returned, which by default will be a `NamedTuple`. See also
+`getproperty`.
+
+# Example
+
+Extract properties `a` and `c` from a `NamedTuple`.
+
+```julia
+julia> nt = (a = 1, b = 2.0, c = false)
+(a = 1, b = 2.0, c = false)
+
+julia> getproperties(:a, :c)(nt)
+(a = 1, c = false)
+```
+"""
+@inline function getproperties(names::Symbol...)
+    return GetProperties(names)
+end
+
+@generated function (::GetProperties{names})(x) where {names}
+    exprs = [:($n = getproperty(x, $(QuoteNode(n)))) for n in names]
+    return Expr(:call, Expr(:call, :propertytype, :x), Expr(:tuple, exprs...))
+end
+
+"""
+    propertytype(x)
+
+Return a constructor for an object similar to `x` that can accept a `NamedTuple` with
+arbitrary properties and support `getproperty`. Used for determining the return type of a
+`getproperties` function. The defaults return type is `NamedTuple`.
+"""
+propertytype(x) = identity # the input is always a `NamedTuple`

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -74,7 +74,7 @@ Return a constructor for an object similar to `x` that can accept a `NamedTuple`
 arbitrary properties and support `getproperty`. Used for determining the return type of a
 `getproperties` function. The defaults return type is `NamedTuple`.
 """
-propertytype(x) = identity # the input is always a `NamedTuple`
+propertytype(x) = identity # the input is always a `NamedTuple`, and so this is the default propertytype
 
 struct Compute{names, F} <: Function
     f::F

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -110,6 +110,12 @@ macro calc(expr)
     # We traverse the expression tree and locate the $ nodes, which we note the name of and
     # replace with getproperty calls
     names = Symbol[]
+
+    if expr isa Expr && expr.head == :$ && length(expr.args) == 1 && expr.args[1] isa Symbol
+        return :($(GetProperty{expr.args[1]}()))
+    end
+
+
     calc_expr!(names, expr)
     return :(Calc{$(tuple(names...))}((x...) -> $expr))
 end
@@ -182,6 +188,11 @@ macro select(exprs...)
     # For each express we extract the output property name and the associated `Calc`.
     names = Symbol[]
     calcs = Expr[]
+
+    if exprs isa Tuple{Vararg{Symbol}}
+        return :($(GetProperties{exprs}()))
+    end
+
     for expr in exprs
         if expr isa Symbol
             push!(names, expr)

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -76,21 +76,21 @@ arbitrary properties and support `getproperty`. Used for determining the return 
 """
 propertytype(x) = identity # the input is always a `NamedTuple`
 
-struct Calc{names, F} <: Function
+struct Compute{names, F} <: Function
     f::F
 end
 
-(::Type{Calc{names}})(f) where {names} = Calc{names, typeof(f)}(f)
+(::Type{Compute{names}})(f) where {names} = Compute{names, typeof(f)}(f)
 
-@generated function (c::Calc{names})(x) where {names}
+@generated function (c::Compute{names})(x) where {names}
     exprs = [:(getproperty(x, $(QuoteNode(n)))) for n in names]
     return Expr(:call, :(c.f), exprs...)
 end
 
 """
-    @calc(...)
+    @compute(...)
 
-The `@calc` macro returns a function which performs a calculation on the properties of an
+The `@compute` macro returns a function which performs a calculation on the properties of an
 object, such as a `NamedTuple`.
 
 The input expression is standard Julia code, with `\$` prepended to property names. For
@@ -102,11 +102,11 @@ example. if you want to refer to a property named `a` then use `\$a` in the expr
 julia> nt = (a = 1, b = 2.0, c = false)
 (a = 1, b = 2.0, c = false)
 
-julia> @calc(\$a + \$b)(nt)
+julia> @compute(\$a + \$b)(nt)
 3.0
 ```
 """
-macro calc(expr)
+macro compute(expr)
     # We traverse the expression tree and locate the $ nodes, which we note the name of and
     # replace with getproperty calls
     names = Symbol[]
@@ -115,16 +115,15 @@ macro calc(expr)
         return :($(GetProperty{expr.args[1]}()))
     end
 
-
-    calc_expr!(names, expr)
-    return :(Calc{$(tuple(names...))}((x...) -> $expr))
+    compute_expr!(names, expr)
+    return :(Compute{$(tuple(names...))}((x...) -> $expr))
 end
 
-function calc_expr!(names::Vector{Symbol}, expr::Expr)
+function compute_expr!(names::Vector{Symbol}, expr::Expr)
     if expr.head == :$
         @assert length(expr.args) == 1
         n = expr.args[1]::Symbol
-        
+
         i = 0
         for j = 1:length(names)
             if names[j] == n
@@ -132,7 +131,7 @@ function calc_expr!(names::Vector{Symbol}, expr::Expr)
                 break
             end
         end
-        if i == 0 
+        if i == 0
             push!(names, n)
             i = length(names)
         end
@@ -140,23 +139,23 @@ function calc_expr!(names::Vector{Symbol}, expr::Expr)
         expr.head = :ref
         expr.args = [:x, i]
     else
-        calc_expr!(names, expr.head)
-        foreach(ex -> calc_expr!(names, ex), expr.args)
+        compute_expr!(names, expr.head)
+        foreach(ex -> compute_expr!(names, ex), expr.args)
     end
 
     return nothing
 end
 
-calc_expr!(names::Vector{Symbol}, expr::Any) = nothing
+compute_expr!(names::Vector{Symbol}, expr::Any) = nothing
 
-struct Select{names, Calcs <: Tuple} <: Function
-    calcs::Calcs
+struct Select{names, Fs <: Tuple} <: Function
+    fs::Fs
 end
 
-(::Type{Select{names}})(calcs::Tuple) where {names} = Select{names, typeof(calcs)}(calcs)
+(::Type{Select{names}})(fs::Tuple) where {names} = Select{names, typeof(fs)}(fs)
 
 @generated function (s::Select{names})(x) where {names}
-    exprs = [:($(names[i]) = (s.calcs[$i])(x)) for i in 1:length(names)]
+    exprs = [:($(names[i]) = (s.fs[$i])(x)) for i in 1:length(names)]
     return Expr(:call, Expr(:call, :propertytype, :x), Expr(:tuple, exprs...))
 end
 
@@ -180,14 +179,14 @@ for example `@select(a)` is synomous with `@select(a = \$a)`.
 julia> nt = (a = 1, b = 2.0, c = false)
 (a = 1, b = 2.0, c = false)
 
-julia> @calc(a, sum_a_b = \$a + \$b)(nt)
+julia> @select(a, sum_a_b = \$a + \$b)(nt)
 (a = 1, sum_a_b = 3.0)
 ```
 """
 macro select(exprs...)
-    # For each express we extract the output property name and the associated `Calc`.
+    # For each express we extract the output property name and the associated `Compute`.
     names = Symbol[]
-    calcs = Expr[]
+    fs = Expr[]
 
     if exprs isa Tuple{Vararg{Symbol}}
         return :($(GetProperties{exprs}()))
@@ -196,13 +195,13 @@ macro select(exprs...)
     for expr in exprs
         if expr isa Symbol
             push!(names, expr)
-            push!(calcs, :(GetProperty{$(QuoteNode(expr))}()))
+            push!(fs, :(GetProperty{$(QuoteNode(expr))}()))
         elseif expr isa Expr && expr.head == :(=)
             @assert length(expr.args) == 2
             push!(names, expr.args[1])
             internal_names = Symbol[]
-            calc_expr!(internal_names, expr.args[2])
-            push!(calcs, :(Calc{$(tuple(internal_names...))}((x...) -> $(expr.args[2]))))
+            compute_expr!(internal_names, expr.args[2])
+            push!(fs, :(Compute{$(tuple(internal_names...))}((x...) -> $(expr.args[2]))))
         else
             error("Bad input to @select")
         end
@@ -210,5 +209,5 @@ macro select(exprs...)
 
     @assert length(unique(names)) == length(names)
 
-    return :(Select{$(tuple(names...))}(tuple($(calcs...))))
+    return :(Select{$(tuple(names...))}(tuple($(fs...))))
 end

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -191,7 +191,7 @@ macro select(exprs...)
             push!(names, expr.args[1])
             internal_names = Symbol[]
             calc_expr!(internal_names, expr.args[2])
-            push!(calcs, :(Calc{$(tuple(internal_names...))}(x -> $(expr.args[2]))))
+            push!(calcs, :(Calc{$(tuple(internal_names...))}((x...) -> $(expr.args[2]))))
         else
             error("Bad input to @select")
         end

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -75,3 +75,129 @@ arbitrary properties and support `getproperty`. Used for determining the return 
 `getproperties` function. The defaults return type is `NamedTuple`.
 """
 propertytype(x) = identity # the input is always a `NamedTuple`
+
+struct Calc{names, F} <: Function
+    f::F
+end
+
+(::Type{Calc{names}})(f) where {names} = Calc{names, typeof(f)}(f)
+
+@generated function (c::Calc{names})(x) where {names}
+    exprs = [:(getproperty(x, $(QuoteNode(n)))) for n in names]
+    return Expr(:call, :(c.f), exprs...)
+end
+
+"""
+    @calc(...)
+
+The `@calc` macro returns a function which performs a calculation on the properties of an
+object, such as a `NamedTuple`.
+
+The input expression is standard Julia code, with `\$` prepended to property names. For
+example. if you want to refer to a property named `a` then use `\$a` in the expression.
+
+# Example
+
+```julia
+julia> nt = (a = 1, b = 2.0, c = false)
+(a = 1, b = 2.0, c = false)
+
+julia> @calc(\$a + \$b)(nt)
+3.0
+```
+"""
+macro calc(expr)
+    # We traverse the expression tree and locate the $ nodes, which we note the name of and
+    # replace with getproperty calls
+    names = Symbol[]
+    calc_expr!(names, expr)
+    return :(Calc{$(tuple(names...))}((x...) -> $expr))
+end
+
+function calc_expr!(names::Vector{Symbol}, expr::Expr)
+    if expr.head == :$
+        @assert length(expr.args) == 1
+        n = expr.args[1]::Symbol
+        
+        i = 0
+        for j = 1:length(names)
+            if names[j] == n
+                i = j
+                break
+            end
+        end
+        if i == 0 
+            push!(names, n)
+            i = length(names)
+        end
+
+        expr.head = :ref
+        expr.args = [:x, i]
+    else
+        calc_expr!(names, expr.head)
+        foreach(ex -> calc_expr!(names, ex), expr.args)
+    end
+
+    return nothing
+end
+
+calc_expr!(names::Vector{Symbol}, expr::Any) = nothing
+
+struct Select{names, Calcs <: Tuple} <: Function
+    calcs::Calcs
+end
+
+(::Type{Select{names}})(calcs::Tuple) where {names} = Select{names, typeof(calcs)}(calcs)
+
+@generated function (s::Select{names})(x) where {names}
+    exprs = [:($(names[i]) = (s.calcs[$i])(x)) for i in 1:length(names)]
+    return Expr(:call, Expr(:call, :propertytype, :x), Expr(:tuple, exprs...))
+end
+
+"""
+    @select(...)
+
+The `@select` macro returns a function which performs an arbitrary transformation of the
+properties of an object, such as a `NamedTuple`.
+
+The input expression is a comma-seperated list of `lhs = rhs` pairs. The `lhs` is the name
+of the new property to calculate. The `rhs is  standard Julia code, with `\$` prepended to
+input property names. For example. if you want to rename an input property `a` to be called
+`b`, use `@select(b = \$a)`.
+
+As a special case, if a property is to be simply replicated the `= rhs` part can be dropped,
+for example `@select(a)` is synomous with `@select(a = \$a)`.
+
+# Example
+
+```julia
+julia> nt = (a = 1, b = 2.0, c = false)
+(a = 1, b = 2.0, c = false)
+
+julia> @calc(a, sum_a_b = \$a + \$b)(nt)
+(a = 1, sum_a_b = 3.0)
+```
+"""
+macro select(exprs...)
+    # For each express we extract the output property name and the associated `Calc`.
+    names = Symbol[]
+    calcs = Expr[]
+    for expr in exprs
+        if expr isa Symbol
+            push!(names, expr)
+            push!(calcs, :(GetProperty{$(QuoteNode(expr))}()))
+        elseif expr isa Expr && expr.head == :(=)
+            @assert length(expr.args) == 2
+            push!(names, expr.args[1])
+            internal_names = Symbol[]
+            calc_expr!(internal_names, expr.args[2])
+            push!(calcs, :(Calc{$(tuple(internal_names...))}(x -> $(expr.args[2]))))
+        else
+            error("Bad input to @select")
+        end
+    end
+
+    @assert length(unique(names)) == length(names)
+
+    return :(Select{$(tuple(names...))}(tuple($(calcs...))))
+end

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -91,9 +91,9 @@ const UNARY_OPERATORS = [:!, :-]
 const BINARY_OPERATORS = [:+, :-, :*, :/, :\, ://, :÷, :×, :∈, :∉, :⊂, :⊆, :⊃, :⊇, :⊄, :⊈, :⊅, :⊉, :(==), :(===), :<, :<=, :>, :>=, :!=, :!==, :\, :≠, :≡, :≢, :≯ ,:≱, :≮, :≰]
 
 """
-    @compute(...)
+    @Compute(...)
 
-The `@compute` macro returns a function which performs a calculation on the properties of an
+The `@Compute` macro returns a function which performs a calculation on the properties of an
 object, such as a `NamedTuple`.
 
 The input expression is standard Julia code, with `\$` prepended to property names. For
@@ -105,11 +105,11 @@ example. if you want to refer to a property named `a` then use `\$a` in the expr
 julia> nt = (a = 1, b = 2.0, c = false)
 (a = 1, b = 2.0, c = false)
 
-julia> @compute(\$a + \$b)(nt)
+julia> @Compute(\$a + \$b)(nt)
 3.0
 ```
 """
-macro compute(expr)
+macro Compute(expr)
     # We traverse the expression tree and locate the $ nodes, which we note the name of and
     # replace with getproperty calls
     names = Symbol[]
@@ -250,18 +250,18 @@ end
 end
 
 """
-    @select(...)
+    @Select(...)
 
-The `@select` macro returns a function which performs an arbitrary transformation of the
+The `@Select` macro returns a function which performs an arbitrary transformation of the
 properties of an object, such as a `NamedTuple`.
 
 The input expression is a comma-seperated list of `lhs = rhs` pairs. The `lhs` is the name
 of the new property to calculate. The `rhs is  standard Julia code, with `\$` prepended to
 input property names. For example. if you want to rename an input property `a` to be called
-`b`, use `@select(b = \$a)`.
+`b`, use `@Select(b = \$a)`.
 
 As a special case, if a property is to be simply replicated the `= rhs` part can be dropped,
-for example `@select(a)` is synomous with `@select(a = \$a)`.
+for example `@Select(a)` is synomous with `@Select(a = \$a)`.
 
 # Example
 
@@ -269,11 +269,11 @@ for example `@select(a)` is synomous with `@select(a = \$a)`.
 julia> nt = (a = 1, b = 2.0, c = false)
 (a = 1, b = 2.0, c = false)
 
-julia> @select(a, sum_a_b = \$a + \$b)(nt)
+julia> @Select(a, sum_a_b = \$a + \$b)(nt)
 (a = 1, sum_a_b = 3.0)
 ```
 """
-macro select(exprs...)
+macro Select(exprs...)
     # For each express we extract the output property name and the associated `Compute`.
     names = Symbol[]
     fs = Expr[]

--- a/test/FlexTable.jl
+++ b/test/FlexTable.jl
@@ -148,21 +148,21 @@
         @test mapreduce(TypedTables.getproperties(:a), (acc, row) -> acc + row.a, t; init = 0) === 6
     end
 
-    @testset "@select and @compute on FlexTables" begin
+    @testset "@Select and @Compute on FlexTables" begin
         t = FlexTable(a = [1, 2, 3], b = [2.0, 4.0, 6.0], c = [true, false, true])
 
-        c = @compute(2*$a)
+        c = @Compute(2*$a)
         @test c(t)::Vector == [2, 4, 6] # (Works because 2 * vector works)
         @test map(c, t)::Vector == [2, 4, 6]
         @test mapview(c, t)::MappedArray == [2, 4, 6]
         @test broadcast(c, t)::Vector == [2, 4, 6]
         @test mapreduce(c, +, t) === 12
 
-        c2 = @compute($b > 3.0)
+        c2 = @Compute($b > 3.0)
         @test filter(c2, t)::FlexTable == FlexTable(a = [2,3], b = [4.0,6.0], c = [false,true])
         @test findall(c2, t)::Vector{Int} == [2, 3]
 
-        s = @select(sum = $a + $b)
+        s = @Select(sum = $a + $b)
         @test s(t)::FlexTable == FlexTable(sum = [3.0, 6.0, 9.0]) # (Works because vector + vector works)
         @test map(s, t)::FlexTable == FlexTable(sum = [3.0, 6.0, 9.0])
         @test mapview(s, t)::FlexTable == FlexTable(sum = [3.0, 6.0, 9.0])

--- a/test/FlexTable.jl
+++ b/test/FlexTable.jl
@@ -33,7 +33,6 @@
     @test [t t; t t]::FlexTable{2} == FlexTable(a = [1 1;2 2;3 3;1 1;2 2;3 3], b = [2.0 2.0; 4.0 4.0; 6.0 6.0; 2.0 2.0; 4.0 4.0; 6.0 6.0])
     @test @inferred(vec(t))::FlexTable{1} == t
 
-
     io = IOBuffer()
     show(io, t)
     str = String(take!(io))
@@ -45,6 +44,7 @@
          2 │ 2  4.0
          3 │ 3  6.0"""
 
+    @test @inferred(getproperties(:b, :a)(t))::FlexTable == FlexTable(b = [2.0, 4.0, 6.0], a = [1, 2, 3])
 
     t2 = empty(t)
     @test t2 isa typeof(t)
@@ -120,6 +120,10 @@
         @test map(getproperty(:a), t)::Vector == [1,2,3]
         @test mapview(getproperty(:a), t)::Vector == [1,2,3]
         @test broadcast(getproperty(:a), t)::Vector == [1,2,3]
+
+        @test @inferred(map(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
+        @test @inferred(mapview(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
+        @test @inferred(broadcast(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
     end
 
     # setproperty!

--- a/test/FlexTable.jl
+++ b/test/FlexTable.jl
@@ -145,20 +145,20 @@
         @test map(TypedTables.getproperties(:a), t)::FlexTable == FlexTable(a = [1,2,3])
         @test mapview(TypedTables.getproperties(:a), t)::FlexTable == FlexTable(a = [1,2,3])
         @test broadcast(TypedTables.getproperties(:a), t) == FlexTable(a = [1,2,3])
-        @test mapreduce(TypedTables.getproperties(:a), (acc, row) -> acc + row.a, t; init = 0) === 6        
+        @test mapreduce(TypedTables.getproperties(:a), (acc, row) -> acc + row.a, t; init = 0) === 6
     end
 
-    @testset "@select and @calc on FlexTables" begin
+    @testset "@select and @compute on FlexTables" begin
         t = FlexTable(a = [1, 2, 3], b = [2.0, 4.0, 6.0], c = [true, false, true])
-        
-        c = @calc(2*$a)
+
+        c = @compute(2*$a)
         @test c(t)::Vector == [2, 4, 6] # (Works because 2 * vector works)
         @test map(c, t)::Vector == [2, 4, 6]
         @test mapview(c, t)::MappedArray == [2, 4, 6]
         @test broadcast(c, t)::Vector == [2, 4, 6]
         @test mapreduce(c, +, t) === 12
 
-        c2 = @calc($b > 3.0)
+        c2 = @compute($b > 3.0)
         @test filter(c2, t)::FlexTable == FlexTable(a = [2,3], b = [4.0,6.0], c = [false,true])
         @test findall(c2, t)::Vector{Int} == [2, 3]
 

--- a/test/FlexTable.jl
+++ b/test/FlexTable.jl
@@ -109,9 +109,9 @@
         t2 = FlexTable(b = [2.0, 4.0, 6.0],)
         t3 = FlexTable(a = [1,2,3], b = [2.0, 4.0, 6.0])
 
-        @test @inferred(map(merge, t1, t2))::FlexTable == t3
-        @test @inferred(mapview(merge, t1, t2))::FlexTable == t3
-        @test @inferred(broadcast(merge, t1, t2))::FlexTable == t3
+        @test (map(merge, t1, t2))::FlexTable == t3
+        @test (mapview(merge, t1, t2))::FlexTable == t3
+        @test (broadcast(merge, t1, t2)) == t3
     end
 
     @testset "GetProperty on FlexTables" begin
@@ -121,9 +121,9 @@
         @test mapview(getproperty(:a), t)::Vector == [1,2,3]
         @test broadcast(getproperty(:a), t)::Vector == [1,2,3]
 
-        @test @inferred(map(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
-        @test @inferred(mapview(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
-        @test @inferred(broadcast(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
+        @test (map(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
+        @test (mapview(getproperties(:a), t))::FlexTable == FlexTable(a = [1,2,3])
+        @test (broadcast(getproperties(:a), t)) == FlexTable(a = [1,2,3])
     end
 
     # setproperty!

--- a/test/Table.jl
+++ b/test/Table.jl
@@ -135,17 +135,17 @@
         @test @inferred(mapreduce(TypedTables.getproperties(:a), (acc, row) -> acc + row.a, t; init = 0)) === 6
     end
 
-    @testset "@select and @calc on Tables" begin
+    @testset "@select and @compute on Tables" begin
         t = Table(a = [1,2,3], b = [2.0, 4.0, 6.0], c = [true, false, true])
-        
-        c = @calc(2*$a)
+
+        c = @compute(2*$a)
         @test @inferred(c(t))::Vector == [2, 4, 6] # (Works because 2 * vector works)
         @test @inferred(map(c, t))::Vector == [2, 4, 6]
         @test @inferred(mapview(c, t))::MappedArray == [2, 4, 6]
         @test @inferred(broadcast(c, t))::Vector == [2, 4, 6]
         @test @inferred(mapreduce(c, +, t)) === 12
 
-        c2 = @calc($b > 3.0)
+        c2 = @compute($b > 3.0)
         @test @inferred(filter(c2, t))::Table == Table(a = [2,3], b = [4.0,6.0], c = [false,true])
         @test @inferred(findall(c2, t))::Vector{Int} == [2, 3]
 

--- a/test/Table.jl
+++ b/test/Table.jl
@@ -1,5 +1,5 @@
 @testset "Table" begin
-    t = @inferred(Table(a = [1,2,3], b = [2.0, 4.0, 6.0]))::Table
+    t = @inferred(Table(a = [1, 2, 3], b = [2.0, 4.0, 6.0]))::Table
 
     @test Table(t) == t
     @test Table(t; c = [true,false,true]) == Table(a = [1,2,3], b = [2.0,4.0,6.0], c = [true,false,true])
@@ -44,6 +44,8 @@
          1 │ 1  2.0
          2 │ 2  4.0
          3 │ 3  6.0"""
+
+    @test @inferred(getproperties(:b, :a)(t))::Table == Table(b = [2.0, 4.0, 6.0], a = [1, 2, 3])
 
     t2 = empty(t)
     @test t2 isa typeof(t)
@@ -119,6 +121,10 @@
         @test @inferred(map(getproperty(:a), t))::Vector == [1,2,3]
         @test @inferred(mapview(getproperty(:a), t))::Vector == [1,2,3]
         @test @inferred(broadcast(getproperty(:a), t))::Vector == [1,2,3]
+
+        @test @inferred(map(getproperties(:a), t))::Table == Table(a = [1,2,3])
+        @test @inferred(mapview(getproperties(:a), t))::Table == Table(a = [1,2,3])
+        @test @inferred(broadcast(getproperties(:a), t))::Table == Table(a = [1,2,3])
     end
 
     @testset "missing in tables" begin

--- a/test/Table.jl
+++ b/test/Table.jl
@@ -135,21 +135,21 @@
         @test @inferred(mapreduce(TypedTables.getproperties(:a), (acc, row) -> acc + row.a, t; init = 0)) === 6
     end
 
-    @testset "@select and @compute on Tables" begin
+    @testset "@Select and @Compute on Tables" begin
         t = Table(a = [1,2,3], b = [2.0, 4.0, 6.0], c = [true, false, true])
 
-        c = @compute(2*$a)
+        c = @Compute(2*$a)
         @test @inferred(c(t))::Vector == [2, 4, 6] # (Works because 2 * vector works)
         @test @inferred(map(c, t))::Vector == [2, 4, 6]
         @test @inferred(mapview(c, t))::MappedArray == [2, 4, 6]
         @test @inferred(broadcast(c, t))::Vector == [2, 4, 6]
         @test @inferred(mapreduce(c, +, t)) === 12
 
-        c2 = @compute($b > 3.0)
+        c2 = @Compute($b > 3.0)
         @test @inferred(filter(c2, t))::Table == Table(a = [2,3], b = [4.0,6.0], c = [false,true])
         @test @inferred(findall(c2, t))::Vector{Int} == [2, 3]
 
-        s = @select(sum = $a + $b)
+        s = @Select(sum = $a + $b)
         @test @inferred(s(t))::Table == Table(sum = [3.0, 6.0, 9.0]) # (Works because vector + vector works)
         @test @inferred(map(s, t))::Table == Table(sum = [3.0, 6.0, 9.0])
         @test @inferred(mapview(s, t))::Table == Table(sum = [3.0, 6.0, 9.0])

--- a/test/Table.jl
+++ b/test/Table.jl
@@ -127,6 +127,22 @@
         @test @inferred(broadcast(getproperties(:a), t))::Table == Table(a = [1,2,3])
     end
 
+    @testset "@select and @calc on Tables" begin
+        t = Table(a = [1,2,3], b = [2.0, 4.0, 6.0])
+        
+        c = @calc(2*$a)
+        @test @inferred(c(t))::Vector == [2, 4, 6] # (Works because 2 * vector works)
+        @test @inferred(map(c, t))::Vector == [2, 4, 6]
+        @test @inferred(mapview(c, t))::MappedArray == [2, 4, 6]
+        @test c.(t)::Vector == [2, 4, 6]
+
+        s = @select(sum = $a + $b)
+        @test @inferred(s(t))::Table == Table(sum = [3.0, 6.0, 9.0]) # (Works because vector + vector works)
+        @test @inferred(map(s, t))::Table == Table(sum = [3.0, 6.0, 9.0])
+        @test @inferred(mapview(s, t))::Table == Table(sum = [3.0, 6.0, 9.0])
+        @test s.(t)::Table == Table(sum = [3.0, 6.0, 9.0])
+    end
+
     @testset "missing in tables" begin
         t = Table(a = [1, 2, 3], b = [2.0, 4.0, missing])
 

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -4,14 +4,14 @@
 
     @test @inferred(TypedTables.getproperties(:b)(nt)) === (b = 2.0,)
 
-    c1 = @calc($b)
+    c1 = @compute($b)
     @test c1 isa TypedTables.GetProperty
     @test @inferred(c1(nt)) === 2.0
 
-    c2 = @calc(2*$b)
+    c2 = @compute(2*$b)
     @test @inferred(c2(nt)) === 4.0
 
-    c3 = @calc($a + 2*$b)
+    c3 = @compute($a + 2*$b)
     @test @inferred(c3(nt)) === 5.0
 
     s1 = @select(a)

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -1,5 +1,27 @@
 @testset "Property interface" begin
-    @test @inferred(getproperty(:b)((a=1,b=2.0,c=false))) === 2.0
+    nt = (a=1,b=2.0,c=false)
+    @test @inferred(getproperty(:b)(nt)) === 2.0
 
-    @test @inferred(getproperties(:b)((a=1,b=2.0,c=false))) === (b = 2.0,)
+    @test @inferred(TypedTables.getproperties(:b)(nt)) === (b = 2.0,)
+
+    c1 = @calc($b)
+    @test c1 isa TypedTables.GetProperty
+    @test @inferred(c1(nt)) === 2.0
+
+    c2 = @calc(2*$b)
+    @test @inferred(c2(nt)) === 4.0
+
+    c3 = @calc($a + 2*$b)
+    @test @inferred(c3(nt)) === 5.0
+
+    s1 = @select(a)
+    @test s1 isa TypedTables.GetProperties
+    @test @inferred(s1(nt)) === (a = 1,)
+
+    s2 = @select(c,b,a)
+    @test s1 isa TypedTables.GetProperties
+    @test @inferred(s2(nt)) === (c = false, b = 2.0, a = 1)
+
+    s3 = @select(a, c = $c, d = $a + 2*$b)
+    @test @inferred(s3(nt)) === (a = 1, c = false, d = 5.0)
 end

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -1,0 +1,5 @@
+@testset "Property interface" begin
+    @test @inferred(getproperty(:b)((a=1,b=2.0,c=false))) === 2.0
+
+    @test @inferred(getproperties(:b)((a=1,b=2.0,c=false))) === (b = 2.0,)
+end

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -4,24 +4,24 @@
 
     @test @inferred(TypedTables.getproperties(:b)(nt)) === (b = 2.0,)
 
-    c1 = @compute($b)
+    c1 = @Compute($b)
     @test c1 isa TypedTables.GetProperty
     @test @inferred(c1(nt)) === 2.0
 
-    c2 = @compute(2*$b)
+    c2 = @Compute(2*$b)
     @test @inferred(c2(nt)) === 4.0
 
-    c3 = @compute($a + 2*$b)
+    c3 = @Compute($a + 2*$b)
     @test @inferred(c3(nt)) === 5.0
 
-    s1 = @select(a)
+    s1 = @Select(a)
     @test s1 isa TypedTables.GetProperties
     @test @inferred(s1(nt)) === (a = 1,)
 
-    s2 = @select(c,b,a)
+    s2 = @Select(c,b,a)
     @test s1 isa TypedTables.GetProperties
     @test @inferred(s2(nt)) === (c = false, b = 2.0, a = 1)
 
-    s3 = @select(a, c = $c, d = $a + 2*$b)
+    s3 = @Select(a, c = $c, d = $a + 2*$b)
     @test @inferred(s3(nt)) === (a = 1, c = false, d = 5.0)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,6 @@ using TypedTables
 using SplitApplyCombine
 using Tables
 
+include("properties.jl")
 include("Table.jl")
 include("FlexTable.jl")


### PR DESCRIPTION
OK, here is a preview of my solution to the properties interface. This replaces #38 and I think this branch will remove the plural-getproperties stuff.

For user-facing tools, there are macros `@Select` and ~~`@calc`~~ `@Compute` which return *functions*. That's right - these aren't direct operations, let's call them "higher-order macros" :)

They are designed to act on any container that support `getproperty`. The `@compute` macro is more-or-less convenient syntax for building a simple anonymous function. You use `$` to indicate any input property and all other parts of the expression are evaluated as written.

```julia
julia> @Compute($a + $b)((a=1, b=2.0))
3.0
```
~~I'd like to think of a better name for `@calc`, so ideas very welcome.~~ In the backend this creates a `Compute` object which is a type of `Function` that knows what property names it requires (useful info for columnar-storage optimizations, ~~still WIP~~ now done).

The `@Select` macro returns an object with a number of properties, possibly simply replicated, and sometimes they are calculations of their own. Here's a preview:

```julia
julia> @Select(a, b = $b, sum = $a + $b)((a=1, b=2.0))
(a = 1, b = 2.0, sum = 3.0)
```
Generally it's a `name = function_expression` pair but you can just nominate a symbol to replicate. This creates a `Select` object which is a type of `Function` that generally contains `GetProperty` or `Compute` objects (again, column names are known for ~~potential~~ implemented columnar-storage optimizations).

This PR does contain columnar-storage optimizations for `GetProperties` in the `columnops.jl` file, from #38 as well as `Compute` and `Select` (we automatically pre-project tables so that iteration works on fewer columns). I don't think we'll need `getproperties` for anything in the end, so I will probably ~~delete~~ not export that. But right now I gotta go to bed.

Now - how to use on a `Table`? Well, you have two options, you can manipulate the table directly, as in `@Select(...)(t)`, which performs a transformation on *columns* as entire arrays. Or you can broadcast this over the rows, as in `@Select(...).(t)` or `map(@Select(...), t)`, and the result can be globbed back into a table (~~the former is still WIP~~).

cc @quinnj compared to what I see in TableOperations.jl, I see this as being more generic/fundamental about properties rather than tables, but still preserving the information critical for columnar-based storage optimizations.

Todos:

 - [x] We should ideally add some columnar accelerations to `mapreduce`, and maybe to `filter` (and `findall`).
 - [x] Tutorial documentation
 - [x] Test coverage
 - [x] Make `@select` not clash with Query.jl (renamed to `@Select`)