### PR TITLE
Add vararg support to hcat and vcat for Table and FlexTable

### DIFF
--- a/src/FlexTable.jl
+++ b/src/FlexTable.jl
@@ -243,24 +243,25 @@ end
 # Private fields are never exposed since they can conflict with column names
 Base.propertynames(t::FlexTable, private::Bool=false) = columnnames(t)
 
-function Base.vcat(t::Union{FlexTable, Table}, t2::Union{FlexTable, Table})
-    return FlexTable{_vcat_ndims(ndims(t), ndims(t2))}(map(vcat, columns(t), columns(t2)))
+
+@inline function Base.vcat(ts::Union{FlexTable, Table}...)
+    return FlexTable{_vcat_ndims(map(ndims, ts)...)}(map(vcat, map(columns, ts)...))
 end
 
-function Base.hcat(t::Union{FlexTable, Table}, t2::Union{FlexTable, Table})
-    return FlexTable{_hcat_ndims(ndims(t), ndims(t2))}(map(hcat, columns(t), columns(t2)))
+@inline function Base.hcat(ts::Union{FlexTable, Table}...)
+    return FlexTable{_hcat_ndims(map(ndims, ts)...)}(map(hcat, map(columns, ts)...))
 end
 
 function Base.hvcat(rows::Tuple{Vararg{Int}}, ts::Union{FlexTable, Table}...)
     return FlexTable(map((cols...,) -> hvcat(rows, cols...), map(columns, ts)...))
 end
 
-@pure function _vcat_ndims(i::Int, j::Int)
-    max(i, j, 1)
+@pure function _vcat_ndims(i::Int...)
+    max(1, i...)
 end
 
-@pure function _hcat_ndims(i::Int, j::Int)
-    max(i, j, 2)
+@pure function _hcat_ndims(i::Int...)
+    max(2, i...)
 end
 
 function Base.vec(t::FlexTable)

--- a/src/Table.jl
+++ b/src/Table.jl
@@ -274,13 +274,28 @@ end
 # Private fields are never exposed since they can conflict with column names
 Base.propertynames(t::Table, private::Bool=false) = columnnames(t)
 
-function Base.vcat(t::Table{<:NamedTuple{names}}, t2::Table{<:NamedTuple{names}}) where {names}
+
+@inline Base.vcat(t::Table) = Table(map(vcat, columns(t)))
+
+@inline function Base.vcat(t::Table{<:NamedTuple{names}}, t2::Table{<:NamedTuple{names}}) where {names}
     return Table(map(vcat, columns(t), columns(t2)))
 end
 
-function Base.hcat(t::Table{<:NamedTuple{names}}, t2::Table{<:NamedTuple{names}}) where {names}
+@inline function Base.vcat(t1::Table{<:NamedTuple{names}}, t2::Table{<:NamedTuple{names}}, ts::Table{<:NamedTuple{names}}...) where {names}
+    return Table(map(vcat, columns(t1), columns(t2), map(columns, ts)...))
+end
+
+
+@inline Base.hcat(t::Table) = Table(map(hcat, columns(t)))
+
+@inline function Base.hcat(t::Table{<:NamedTuple{names}}, t2::Table{<:NamedTuple{names}}) where {names}
     return Table(map(hcat, columns(t), columns(t2)))
 end
+
+@inline function Base.hcat(t1::Table{<:NamedTuple{names}}, t2::Table{<:NamedTuple{names}}, ts::Table{<:NamedTuple{names}}...) where {names}
+    return Table(map(hcat, columns(t1), columns(t2), map(columns, ts)...))
+end
+
 
 function Base.hvcat(rows::Tuple{Vararg{Int}}, tables::Table{<:NamedTuple{names}}...) where {names}
     return Table(map((cols...,) -> hvcat(rows, cols...), map(columns, tables)...))

--- a/test/FlexTable.jl
+++ b/test/FlexTable.jl
@@ -33,12 +33,10 @@
     @test @inferred(vcat(t))::FlexTable{1} == t
     @test @inferred(vcat(t, t))::FlexTable{1} == FlexTable(a = [1,2,3,1,2,3], b = [2.0, 4.0, 6.0, 2.0, 4.0, 6.0])
     @test @inferred(vcat(t, t, t))::FlexTable{1} == FlexTable(a = [1,2,3,1,2,3,1,2,3], b = [2.0, 4.0, 6.0, 2.0, 4.0, 6.0, 2.0, 4.0, 6.0])
-    @test @inferred(vcat(t, t))::FlexTable{1} == FlexTable(a = [1,2,3,1,2,3], b = [2.0, 4.0, 6.0, 2.0, 4.0, 6.0])
 
     @test @inferred(hcat(t))::FlexTable{2} == FlexTable(a = hcat([1; 2; 3]), b = hcat([2.0; 4.0; 6.0]))
     @test @inferred(hcat(t, t))::FlexTable{2} == FlexTable(a = [1 1;2 2;3 3], b = [2.0 2.0; 4.0 4.0; 6.0 6.0])
     @test @inferred(hcat(t, t, t))::FlexTable{2} == FlexTable(a = [1 1 1;2 2 2;3 3 3], b = [2.0 2.0 2.0; 4.0 4.0 4.0; 6.0 6.0 6.0])
-    @test @inferred(hcat(t, t))::FlexTable{2} == FlexTable(a = [1 1;2 2;3 3], b = [2.0 2.0; 4.0 4.0; 6.0 6.0])
     
     @test [t t; t t]::FlexTable{2} == FlexTable(a = [1 1;2 2;3 3;1 1;2 2;3 3], b = [2.0 2.0; 4.0 4.0; 6.0 6.0; 2.0 2.0; 4.0 4.0; 6.0 6.0])
     @test @inferred(vec(t))::FlexTable{1} == t

--- a/test/FlexTable.jl
+++ b/test/FlexTable.jl
@@ -30,8 +30,16 @@
     @test similar(t) isa typeof(t)
     @test axes(similar(t)) === axes(t)
 
+    @test @inferred(vcat(t))::FlexTable{1} == t
     @test @inferred(vcat(t, t))::FlexTable{1} == FlexTable(a = [1,2,3,1,2,3], b = [2.0, 4.0, 6.0, 2.0, 4.0, 6.0])
+    @test @inferred(vcat(t, t, t))::FlexTable{1} == FlexTable(a = [1,2,3,1,2,3,1,2,3], b = [2.0, 4.0, 6.0, 2.0, 4.0, 6.0, 2.0, 4.0, 6.0])
+    @test @inferred(vcat(t, t))::FlexTable{1} == FlexTable(a = [1,2,3,1,2,3], b = [2.0, 4.0, 6.0, 2.0, 4.0, 6.0])
+
+    @test @inferred(hcat(t))::FlexTable{2} == FlexTable(a = hcat([1; 2; 3]), b = hcat([2.0; 4.0; 6.0]))
     @test @inferred(hcat(t, t))::FlexTable{2} == FlexTable(a = [1 1;2 2;3 3], b = [2.0 2.0; 4.0 4.0; 6.0 6.0])
+    @test @inferred(hcat(t, t, t))::FlexTable{2} == FlexTable(a = [1 1 1;2 2 2;3 3 3], b = [2.0 2.0 2.0; 4.0 4.0 4.0; 6.0 6.0 6.0])
+    @test @inferred(hcat(t, t))::FlexTable{2} == FlexTable(a = [1 1;2 2;3 3], b = [2.0 2.0; 4.0 4.0; 6.0 6.0])
+    
     @test [t t; t t]::FlexTable{2} == FlexTable(a = [1 1;2 2;3 3;1 1;2 2;3 3], b = [2.0 2.0; 4.0 4.0; 6.0 6.0; 2.0 2.0; 4.0 4.0; 6.0 6.0])
     @test @inferred(vec(t))::FlexTable{1} == t
 

--- a/test/Table.jl
+++ b/test/Table.jl
@@ -31,8 +31,14 @@
     @test similar(t) isa typeof(t)
     @test axes(similar(t)) === axes(t)
 
+    @test @inferred(vcat(t))::Table == t
     @test @inferred(vcat(t, t))::Table == Table(a = [1,2,3,1,2,3], b = [2.0, 4.0, 6.0, 2.0, 4.0, 6.0])
+    @test @inferred(vcat(t, t, t))::Table == Table(a = [1,2,3,1,2,3,1,2,3], b = [2.0, 4.0, 6.0, 2.0, 4.0, 6.0, 2.0, 4.0, 6.0])
+
+    @test @inferred(hcat(t))::Table == Table(a = hcat([1; 2; 3]), b = hcat([2.0; 4.0; 6.0]))
     @test @inferred(hcat(t, t))::Table == Table(a = [1 1;2 2;3 3], b = [2.0 2.0; 4.0 4.0; 6.0 6.0])
+    @test @inferred(hcat(t, t, t))::Table == Table(a = [1 1 1;2 2 2;3 3 3], b = [2.0 2.0 2.0; 4.0 4.0 4.0; 6.0 6.0 6.0])
+
     @test [t t; t t]::Table == Table(a = [1 1;2 2;3 3;1 1;2 2;3 3], b = [2.0 2.0; 4.0 4.0; 6.0 6.0; 2.0 2.0; 4.0 4.0; 6.0 6.0])
     @test @inferred(vec(t))::Table == t
 


### PR DESCRIPTION
This adds

```julia
vcat(table1, table2, ...)
hcat(table1, table2, ...)
```

for `Table` and `FlexTable`. It also ensures

```julia
vcat(table) === table
hcat(table) === table
```

CC @andyferris 