### PR TITLE
WIP Add DataTable

### DIFF
--- a/src/DataRow.jl
+++ b/src/DataRow.jl
@@ -1,0 +1,58 @@
+"""
+    DataRow(index, colnames, data, i)
+
+A `DataRow` is used as a reference to a row of a `DataTable`. It behaves similary to a
+`NamedTuple`, except relies on a dynamic hash map and dynamic typing, and supports mutation
+(which mutates the parent `DataTable`).
+"""
+struct DataRow{N}
+    index::Dict{Symbol, Int}
+    colnames::Vector{Symbol}
+    data::Vector{AbstractArray{<:Any, N}}
+    i::Int # Assume DataTable is IndexLinear...
+end
+
+# Interface like a NamedTuple
+function Base.getproperty(r::DataRow, s::Symbol)
+    col_i = getfield(r, :index)[s]
+    return @inbounds getfield(r, :data)[col_i][getfield(r, :i)] # We have already checked bounds of r.i
+end
+Base.propertynames(r::DataRow) = getfield(r, :colnames)
+
+@inline Base.getindex(r::DataRow, s::Symbol) = getproperty(r, s)
+@inline Base.iterate(r::DataRow, s...) = iterate(r.data, s...)
+@inline Base.length(r::DataRow) = length(getfield(r, :data))
+@inline Base.keys(r::DataRow) = getfield(r, :data)
+@inline Base.haskey(r::DataRow, s::Symbol) = haskey(getfield(r, :index), s::Symbol)
+@inline Base.pairs(r::DataRow) = zip(getfield(r, :colnames), getfield(r, :data))
+
+# We can mutate the elements by mutating the DataTable
+function Base.setproperty!(r::DataRow, s::Symbol, v)
+    col_i = getfield(r, :index)[s]
+    @inbounds getfield(r, :data)[col_i][getfield(r, :i)] = v
+    return r
+end
+@inline Base.setindex!(r::DataRow, v, s::Symbol) = setproperty!(r, s, v)
+
+# Can convert to a NamedTuple
+NamedTuple(r::DataRow) = NamedTuple{Tuple(getfield(r, :colnames))}(Tuple(map(x -> getindex(x, getfield(r, :i)), getfield(r, :data))))
+
+# show
+# TODO this printing should probably only be the "compact" form, otherwise maybe we should
+# differentiate a bit from NamedTuple?
+Base.show(io::IO, t::DataRow) = show(io, MIME"text/plain"(), r)
+function Base.show(io::IO, ::MIME"text/plain", r::DataRow)
+    colnames = getfield(r, :colnames)
+    data = getfield(r, :data)
+    index = getfield(r, :i)
+    print(io, "(")
+    for (i, colname) in enumerate(colnames)
+        print(io, colname)
+        print(io, " = ")
+        print(io, data[i][index])
+        if i == 1 || i < length(data)
+            print(io, ", ")
+        end
+    end
+    print(io, ")")
+end

--- a/src/DataTable.jl
+++ b/src/DataTable.jl
@@ -1,0 +1,98 @@
+
+
+struct DataTable{N} <: AbstractArray{DataRow{N}, N}
+    index::Dict{Symbol, Int}
+    columns::Vector{Symbol}
+    data::Vector{AbstractArray{<:Any, N}}
+end
+
+# Construction
+DataTable(; kwargs...) = DataTable{_ndims(kwargs.data)}(; kwargs...)
+DataTable(ts::AbstractArray{<:Any, N}...; kwargs...) where {N} = DataTable{N}(ts...; kwargs...)
+
+function DataTable{N}(ts...; kwargs...) where {N}
+    index = Dict{Symbol, Int}()
+    colnames = Vector{Symbol}()
+    data = Vector{AbstractArray{<:Any,N}}()
+
+    for t in ts
+        for (colname, column) in pairs(columns(t))
+            token = Base.ht_keyindex2!(index, colname)
+            if token < 0
+                # Add a new column
+                push!(colnames, colname)
+                push!(data, column)
+                Base._setindex!(index, length(colnames), colname, -token)
+            else
+                # Replace the column (merge)
+                @inbounds data[index.vals[token]] = column
+            end
+        end
+    end
+
+    for (colname, column) in kwargs
+        token = Base.ht_keyindex2!(index, colname)
+        if token < 0
+            # Add a new column
+            push!(colnames, colname)
+            push!(data, column)
+            Base._setindex!(index, length(colnames), colname, -token)
+        else
+            if column === nothing
+                # Delete the column
+                col_i = @inbounds index.vals[token]
+                deleteat!(colnames, col_i)
+                deleteat!(data, col_i)
+                Base._delete!(index, token)
+            else
+                # Replace the column (merge)
+                @inbounds data[index.vals[token]] = column
+            end
+        end
+    end
+
+    DataTable{N}(index, colnames, data)
+end
+
+# Conversion between other table types
+Table(t::DataTable) = Table(NamedTuple(columns(t)))
+FlexTable(t::DataTable) = Table(NamedTuple(columns(t)))
+
+# Column names are a vector, in this case
+columnnames(t::DataTable) = getfield(t, :columns)
+
+# Basic access interface
+Base.IndexStyle(::Type{<:DataTable}) = Base.IndexLinear()
+@inline function Base.getindex(t::DataTable{N}, i::Int) where {N}
+    # Check bounds here once during row construction, rather than during each cell access.
+    @boundscheck checkbounds(getfield(t, :data)[1], i)
+    return DataRow{N}(getfield(t, :index), getfield(t, :columns), getfield(t, :data), i)
+end
+Base.length(t::DataTable) = length(first(getfield(t, :data)))
+Base.size(t::DataTable) = size(first(getfield(t, :data)))
+Base.axes(t::DataTable) = axes(first(getfield(t, :data)))
+
+function Base.getproperty(t::DataTable, s::Symbol)
+    col_i = t.index[s]
+    return @inbounds t.data[col_i]
+end
+
+# Tables.jl interface
+Tables.istable(::Type{<:DataTable}) = true
+Tables.rowaccess(::Type{<:DataTable}) = true 
+Tables.columnaccess(::Type{<:DataTable}) = true
+Tables.schema(t::DataTable) = Tables.Schema(getfield(t, :colnames), map(eltype, getfield(t, :data)))
+Tables.materializer(::DataTable{N}) where {N} = Table  # Currently, all the Tables.jl stuff quickly becomes fully-typed... probably a bad idea!
+
+"""
+    columns(table::DataTable)
+
+Convert a `DataTable` into `NamedTuple` of it's columns.
+"""
+@inline Tables.columns(t::DataTable) = NamedTuple{Tuple(getfield(t, :colnames))}(Tuple(getfield(t, :data))) # ??
+
+@inline Tables.rows(t::DataTable) = Table(columns(t)) # ??
+
+# show
+Base.show(io::IO, ::MIME"text/plain", t::DataTable) = showtable(io, t)
+Base.show(io::IO, t::DataTable) = showtable(io, t)

--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -8,7 +8,7 @@ using Base: @propagate_inbounds, @pure, OneTo, Fix2
 import Tables.columns, Tables.rows
 
 export @Compute, @Select
-export Table, FlexTable, columns, rows, columnnames, showtable
+export Table, FlexTable, DataTable, DataRow, columns, rows, columnnames, showtable
 
 # Resultant element type of given column arrays
 @generated function _eltypes(a::NamedTuple{names, T}) where {names, T <: Tuple{Vararg{AbstractArray}}}
@@ -37,6 +37,8 @@ end
 include("properties.jl")
 include("Table.jl")
 include("FlexTable.jl")
+include("DataRow.jl")
+include("DataTable.jl")
 include("columnops.jl")
 include("show.jl")
 

--- a/test/DataTable.jl
+++ b/test/DataTable.jl
@@ -1,0 +1,7 @@
+@testset "DataTable" begin
+    t = @inferred(DataTable(a = [1,2,3], b = [2.0, 4.0, 6.0]))::DataTable{1}
+
+    @test DataTable(t; c = [true,false,true]) == Table(a = [1,2,3], b = [2.0,4.0,6.0], c = [true,false,true])
+    @test DataTable(t, Table(c = [true,false,true])) == Table(a = [1,2,3], b = [2.0,4.0,6.0], c = [true,false,true])
+    @test DataTable(t; b = nothing) == Table(a = [1,2,3])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,3 +6,4 @@ using Tables
 include("properties.jl")
 include("Table.jl")
 include("FlexTable.jl")
+include("DataTable.jl")


### PR DESCRIPTION
Dynamically typed and hash-based column lookup for tables with large
numbers of columns (especially those of complex types like
Union{Missing, T} which seems to bog down the compiler).

Basically this is a DataFrame with an interface closer to a Table.