### PR TITLE
Version check workaround for JuliaLang/julia#29970

### DIFF
--- a/src/TypedTables.jl
+++ b/src/TypedTables.jl
@@ -22,15 +22,20 @@ end
 _ndims(a::NamedTuple{<:Any, T}) where {T} = _ndims(T)
 _ndims(::Type{<:Tuple{Vararg{AbstractArray{<:Any, n}}}}) where {n} = n
 
-# Workaround for JuliaLang/julia#29970
-let
-    for n in 1:32
-        Ts = [Symbol("T$i") for i in 1:n]
-        xs = [:(x[$i]) for i in 1:n]
-        NT = :(Core.NamedTuple{names, Tuple{$(Ts...)}})
-        eval(quote
-            $NT(x::Tuple{$(Ts...)}) where {names, $(Ts...)} = $(Expr(:new, NT, xs...))
-        end)
+# The following code causes newer versions of Julia to hang in precompilation
+# and the workaround should not be needed after JuliaLang/julia#30577 was
+# merged.
+if VERSION < v"1.2.0-DEV.291"
+    # Workaround for JuliaLang/julia#29970
+    let
+        for n in 1:32
+            Ts = [Symbol("T$i") for i in 1:n]
+            xs = [:(x[$i]) for i in 1:n]
+            NT = :(Core.NamedTuple{names, Tuple{$(Ts...)}})
+            eval(quote
+                $NT(x::Tuple{$(Ts...)}) where {names, $(Ts...)} = $(Expr(:new, NT, xs...))
+            end)
+        end
     end
 end
 


### PR DESCRIPTION
The workaround for JuliaLang/julia#29970 causes newer versions of Julia
to hang in the precompilation step for TypedTables.

Since JuliaLang/julia#29970 has been addressed in JuliaLang/julia#30577
the code is avoided in newer versions of Julia.