### PR TITLE
Also test on Julia v1.2, switch from REQUIRE to Project.toml, increase version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - 1.0
+  - 1.2
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,15 @@
 authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 name = "TypedTables"
 uuid = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[compat]
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Andy Ferris <ferris.andy@gmail.com>"]
 name = "TypedTables"
 uuid = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-SplitApplyCombine
-Tables

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.0
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:


### PR DESCRIPTION
This enables testing on Julia v1.2 (works now, see #48) and gets TypedTables ready for Registrator.

@andyferris , if this goes through CI, would you consider a timely release (hard to test some of my packages on Julia v1.2-RC1 without TypedTables)?

The last commit increases the version of TypedTables to v1.2.0 - is this fine? Or should it be v1.1.1?